### PR TITLE
Update kube api resources

### DIFF
--- a/examples/gce/echoserver/deployment.yaml
+++ b/examples/gce/echoserver/deployment.yaml
@@ -1,12 +1,26 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
+  labels:
+    app: echoserver
   name: echoserver
   namespace: echoserver
 spec:
+  progressDeadlineSeconds: 2147483647
   replicas: 1
+  revisionHistoryLimit: 2147483647
+  selector:
+    matchLabels:
+      app: echoserver
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: echoserver
     spec:
@@ -16,3 +30,13 @@ spec:
         name: echoserver
         ports:
         - containerPort: 8080
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status: {}

--- a/examples/gce/lego/deployment.yaml
+++ b/examples/gce/lego/deployment.yaml
@@ -1,44 +1,73 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
+  labels:
+    app: kube-lego
   name: kube-lego
   namespace: kube-lego
 spec:
+  progressDeadlineSeconds: 2147483647
   replicas: 1
+  revisionHistoryLimit: 2147483647
+  selector:
+    matchLabels:
+      app: kube-lego
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
+      creationTimestamp: null
       labels:
-        # Required for the auto-create kube-lego-nginx service to work.
         app: kube-lego
     spec:
       containers:
-      - name: kube-lego
-        image: jetstack/kube-lego:0.1.3
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 8080
-        env:
+      - env:
         - name: LEGO_EMAIL
           valueFrom:
             configMapKeyRef:
-              name: kube-lego
               key: lego.email
+              name: kube-lego
         - name: LEGO_URL
           valueFrom:
             configMapKeyRef:
-              name: kube-lego
               key: lego.url
+              name: kube-lego
         - name: LEGO_NAMESPACE
           valueFrom:
             fieldRef:
+              apiVersion: v1
               fieldPath: metadata.namespace
         - name: LEGO_POD_IP
           valueFrom:
             fieldRef:
+              apiVersion: v1
               fieldPath: status.podIP
+        image: jetstack/kube-lego:0.1.3
+        imagePullPolicy: Always
+        name: kube-lego
+        ports:
+        - containerPort: 8080
+          protocol: TCP
         readinessProbe:
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
           timeoutSeconds: 1
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status: {}

--- a/examples/nginx/echoserver/deployment.yaml
+++ b/examples/nginx/echoserver/deployment.yaml
@@ -1,12 +1,26 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
+  labels:
+    app: echoserver
   name: echoserver
   namespace: echoserver
 spec:
+  progressDeadlineSeconds: 2147483647
   replicas: 1
+  revisionHistoryLimit: 2147483647
+  selector:
+    matchLabels:
+      app: echoserver
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: echoserver
     spec:
@@ -16,3 +30,13 @@ spec:
         name: echoserver
         ports:
         - containerPort: 8080
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status: {}

--- a/examples/nginx/lego/deployment.yaml
+++ b/examples/nginx/lego/deployment.yaml
@@ -1,43 +1,73 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
+  labels:
+    app: kube-lego
   name: kube-lego
   namespace: kube-lego
 spec:
+  progressDeadlineSeconds: 2147483647
   replicas: 1
+  revisionHistoryLimit: 2147483647
+  selector:
+    matchLabels:
+      app: kube-lego
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: kube-lego
     spec:
       containers:
-      - name: kube-lego
-        image: jetstack/kube-lego:0.1.3
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 8080
-        env:
+      - env:
         - name: LEGO_EMAIL
           valueFrom:
             configMapKeyRef:
-              name: kube-lego
               key: lego.email
+              name: kube-lego
         - name: LEGO_URL
           valueFrom:
             configMapKeyRef:
-              name: kube-lego
               key: lego.url
+              name: kube-lego
         - name: LEGO_NAMESPACE
           valueFrom:
             fieldRef:
+              apiVersion: v1
               fieldPath: metadata.namespace
         - name: LEGO_POD_IP
           valueFrom:
             fieldRef:
+              apiVersion: v1
               fieldPath: status.podIP
+        image: jetstack/kube-lego:0.1.3
+        imagePullPolicy: Always
+        name: kube-lego
+        ports:
+        - containerPort: 8080
+          protocol: TCP
         readinessProbe:
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
           timeoutSeconds: 1
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status: {}

--- a/examples/nginx/nginx/default-deployment.yaml
+++ b/examples/nginx/nginx/default-deployment.yaml
@@ -1,30 +1,46 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
+  labels:
+    app: default-http-backend
   name: default-http-backend
   namespace: nginx-ingress
 spec:
+  progressDeadlineSeconds: 2147483647
   replicas: 1
+  revisionHistoryLimit: 2147483647
+  selector:
+    matchLabels:
+      app: default-http-backend
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: default-http-backend
     spec:
       containers:
-      - name: default-http-backend
-        # Any image is permissable as long as:
-        # 1. It serves a 404 page at /
-        # 2. It serves 200 on a /healthz endpoint
-        image: gcr.io/google_containers/defaultbackend:1.0
+      - image: gcr.io/google_containers/defaultbackend:1.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
           timeoutSeconds: 5
+        name: default-http-backend
         ports:
         - containerPort: 8080
+          protocol: TCP
         resources:
           limits:
             cpu: 10m
@@ -32,3 +48,11 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status: {}

--- a/examples/nginx/nginx/deployment.yaml
+++ b/examples/nginx/nginx/deployment.yaml
@@ -1,39 +1,69 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
+  labels:
+    app: nginx
   name: nginx
   namespace: nginx-ingress
 spec:
+  progressDeadlineSeconds: 2147483647
   replicas: 1
+  revisionHistoryLimit: 2147483647
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: nginx
     spec:
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
-        name: nginx
-        imagePullPolicy: Always
+      - args:
+        - /nginx-ingress-controller
+        - --default-backend-service=nginx-ingress/default-http-backend
+        - --nginx-configmap=nginx-ingress/nginx
         env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
+        imagePullPolicy: Always
         livenessProbe:
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 10254
             scheme: HTTP
           initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
           timeoutSeconds: 5
+        name: nginx
         ports:
         - containerPort: 80
+          protocol: TCP
         - containerPort: 443
-        args:
-        - /nginx-ingress-controller
-        - --default-backend-service=nginx-ingress/default-http-backend
-        - --nginx-configmap=nginx-ingress/nginx
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status: {}


### PR DESCRIPTION
Hello there,

In preparation for upgrading to Kubernetes v1.16, (note: we have recently upgraded to v1.13), we have made changes to some of your kubernetes manifests.

The v1.16 release will stop serving a number of deprecated API versions in favor of newer and more stable API versions. For us, this means DaemonSet, Deployment, StatefulSet, and ReplicaSet all need to be updated to be using apps/v1. 

Any manifests referencing deprecated APIs (extensions/v1beta1, apps/v1beta1, or apps/v1beta2) will need to be updated before we roll out Kubernetes v1.16 in order to continue to work.

To lessen the work, we have gone through all the repositories and updated the resource APIs for you. We have pushed any changes to the `machinegun-<randomstring>` branch so feel free to make any changes and/or updates to this branch.

Note: If you are making changes, specifically to Deployments, make sure that you leave the Selector field under the Spec section as this is now mandatory.

During the conversion process, resources may have been updated with defaults and/or changed API fields. The defaults that you see were already in use but are now explicitly set.

Cosmetic changes may have also occurred, for example API fields may have moved around and comments may have been removed. Feel free to move API fields back to their original positions and re-add comments.

We appreciate your assistance in ensuring a smooth transition to Kubernetes v1.16.

If you have any questions, message in #cloud-infrastructure.

Thanks,

Cloud Team