### PR TITLE
Switch to using Uswitch internal docker registry

### DIFF
--- a/examples/gce/lego/deployment.yaml
+++ b/examples/gce/lego/deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: kube-lego
-        image: jetstack/kube-lego:0.1.3
+        image: registry.usw.co/jetstack/kube-lego:0.1.3
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/examples/nginx/lego/deployment.yaml
+++ b/examples/nginx/lego/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: kube-lego
-        image: jetstack/kube-lego:0.1.3
+        image: registry.usw.co/jetstack/kube-lego:0.1.3
         imagePullPolicy: Always
         ports:
         - containerPort: 8080


### PR DESCRIPTION
Hello there,

We thought it would be helpful to update the docker images
all over the place so builds won't break on Monday.

We have gone ahead and pulled the relevant images from Dockerhub
and pushed them to our registry at registry.usw.co.

Please verify that your images need to be changed before merging

If you have any questions, message in #cloud-infrastructure.

Thanks,

Cloud Team